### PR TITLE
cli_test_dir: Add tons of new features

### DIFF
--- a/cli_test_dir/README.md
+++ b/cli_test_dir/README.md
@@ -3,9 +3,14 @@
 [![Latest version](https://img.shields.io/crates/v/cli_test_dir.svg)](https://crates.io/crates/cli_test_dir) [![License](https://img.shields.io/crates/l/cli_test_dir.svg)](https://opensource.org/licenses/MIT) [![Build Status](https://travis-ci.org/emk/subtitles-rs.svg?branch=master)](https://travis-ci.org/emk/subtitles-rs) [![Build status](https://ci.appveyor.com/api/projects/status/3hn8cwckcdhpcasm/branch/master?svg=true)](https://ci.appveyor.com/project/emk/subtitles-rs/branch/master) [![Documentation](https://img.shields.io/badge/documentation-docs.rs-yellow.svg)](https://docs.rs/cli_test_dir/)
 
 For documentation and example code, please see
-the [API docs](https://docs.rs/cli_test_dir/).
+the [API docs](https://docs.rs/cli_test_dir/).  This library was inspired
+by a testing pattern in BurntSushi's Rust code.
 
 ## Contributing
 
 Your feedback and contributions are welcome!  For more information, see
 the [subtitles-rs][] project.
+
+Thank you to
+[![Faraday](http://www.faraday.io/assets/faraday-logo.svg)](http://www.faraday.io/)
+for supporting better integration testing for Rust command-line utilities.

--- a/cli_test_dir/fixtures/input.txt
+++ b/cli_test_dir/fixtures/input.txt
@@ -1,0 +1,1 @@
+Hello, world!

--- a/cli_test_dir/src/lib.rs
+++ b/cli_test_dir/src/lib.rs
@@ -10,28 +10,93 @@
 //! cli_test_dir = "*"
 //! ```
 //!
-//! Then add the following at the top of `tests/tests.rs`:
+//! Then add the following to the top of `tests/tests.rs`:
 //!
-//! ```no_run
+//! ```rust,no_run
 //! extern crate cli_test_dir;
 //! ```
 //!
-//! Once this is done, you can set up a simple test.
+//! You should now be able to write tests as follows:
 //!
-//! ```no_run
-//! use cli_test_dir::TestDir;
+//! ```
+//! use cli_test_dir::*;
 //!
 //! #[test]
 //! fn write_output_file() {
-//!     let testdir = TestDir::new("mybin", "write_output_file");
-//!     let status = testdir.cmd()
-//!         .arg("-o")
+//!     let testdir = TestDir::new("myapp", "write_output_file");
+//!     testdir.cmd()
 //!         .arg("out.txt")
-//!         .status()
-//!         .expect("could not run mybin");
-//!     assert!(status.success());
+//!         .expect_success();
 //!     testdir.expect_path("out.txt");
 //! }
+//! ```
+//!
+//! You can use any options from [`std::process::Command`][Command] to invoke
+//! your program.
+//!
+//! [Command]: https://doc.rust-lang.org/std/process/struct.Command.html
+//!
+//! ## Testing that the program ran successfully
+//!
+//! To check that a command succeeds, we can write:
+//!
+//! ```
+//! # use cli_test_dir::*;
+//! let testdir = TestDir::new("true", "true_succeeds");
+//! testdir.cmd().expect_success();
+//! ```
+//!
+//! But this test would fail:
+//!
+//! ```rust,should_panic
+//! # use cli_test_dir::*;
+//! // Fails.
+//! let testdir = TestDir::new("false", "false_succeeds");
+//! testdir.cmd().expect_success();
+//! ```
+//!
+//! ## File input and output
+//!
+//! The `src_path` function can be used to build paths relative to the
+//! top-level of our crate, and `expect_path` can be used to make sure an
+//! output file exists:
+//!
+//! ```
+//! # use cli_test_dir::*;
+//! let testdir = TestDir::new("cp", "cp_copies_files");
+//! testdir.cmd()
+//!   .arg(testdir.src_path("fixtures/input.txt"))
+//!   .arg("output.txt")
+//!   .expect_success();
+//! testdir.expect_path("output.txt");
+//! ```
+//!
+//! We can also create the input file manually or look for specific
+//! contents in the output file if we wish:
+//!
+//! ```
+//! # use cli_test_dir::*;
+//! let testdir = TestDir::new("cp", "cp_copies_files_2");
+//! testdir.create_file("input.txt", "Hello, world!\n");
+//! testdir.cmd()
+//!   .arg("input.txt")
+//!   .arg("output.txt")
+//!   .expect_success();
+//! testdir.expect_contains("output.txt", "Hello");
+//! testdir.expect_file_contents("output.txt", "Hello, world!\n");
+//! ```
+//!
+//! ## Standard input and output
+//!
+//! We can also test standard input and output:
+//!
+//! ```
+//! # use cli_test_dir::*;
+//! let testdir = TestDir::new("cat", "cat_passes_data_through");
+//! let output = testdir.cmd()
+//!   .output_with_stdin("Hello\n")
+//!   .expect_success();
+//! assert_eq!(output.stdout_str(), "Hello\n");
 //! ```
 //!
 //! ## Contributing
@@ -43,9 +108,13 @@
 //! [xsv]: https://github.com/BurntSushi/xsv
 
 use std::env;
+use std::fmt;
 use std::fs;
+use std::io;
+use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process;
+use std::str;
 use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 use std::thread;
 use std::time;
@@ -102,8 +171,17 @@ impl TestDir {
             panic!("Could not create test output directory: {}", e);
         }
 
+        let mut bin = bin_dir.join(&bin_name);
+        if !bin.exists() {
+            writeln!(io::stderr(),
+                     "WARNING: could not find {}, will search PATH",
+                     bin.display())
+                .expect("could not write to stderr");
+            bin = Path::new(&bin_name).to_owned();
+        }
+
         TestDir {
-            bin: bin_dir.join(&bin_name),
+            bin: bin,
             dir: dir,
         }
     }
@@ -124,9 +202,163 @@ impl TestDir {
             .expect("Could not canonicalize path")
     }
 
+    /// Create a file in our test directory with the specified contents.
+    pub fn create_file<P, S>(&self, path: P, contents: S)
+        where P: AsRef<Path>, S: AsRef<[u8]>
+    {
+        let path = self.dir.join(path);
+        fs::create_dir_all(path.parent().expect("expected parent"))
+            .expect("could not create directory");
+        let mut f = fs::File::create(&path).expect("can't create file");
+        f.write_all(contents.as_ref()).expect("can't write to file");
+    }
+
     /// If `path` does not point to valid path, fail the current test.
     pub fn expect_path<P: AsRef<Path>>(&self, path: P) {
         let path = self.dir.join(path);
         assert!(path.exists(), format!("{} exists", path.display()));
+    }
+
+    /// Verify that the file contains the specified data.
+    pub fn expect_file_contents<P, S>(&self, path: P, expected: S)
+        where P: AsRef<Path>, S: AsRef<[u8]>
+    {
+        let path = self.dir.join(path);
+        let expected = expected.as_ref();
+        self.expect_path(&path);
+        let mut f = fs::File::open(&path).expect("could not open file");
+        let mut found = vec![];
+        f.read_to_end(&mut found).expect("could not read file");
+        expect_data_eq(path.display(), &found, expected);
+    }
+
+    /// Verify that the contents of the file match the specified pattern.
+    /// Someday this should support `std::str::pattern::Pattern` so that we
+    /// can support both strings and regular expressions, but that hasn't
+    /// been stabilized yet.
+    pub fn expect_contains<P>(&self, path: P, pattern: &str)
+        where P: AsRef<Path>
+    {
+        let path = self.dir.join(path);
+        self.expect_path(&path);
+        let mut f = fs::File::open(&path).expect("could not open file");
+        let mut found = vec![];
+        f.read_to_end(&mut found).expect("could not read file");
+        let found = str::from_utf8(&found).expect("expected UTF-8 file");
+        assert!(found.contains(pattern),
+                format!("expected {} to match {:?}, but it contained {:?}",
+                        path.display(), pattern, found));
+    }
+}
+
+/// Internal helper function which compares to blobs of potentially binary data.
+fn expect_data_eq<D>(source: D, found: &[u8], expected: &[u8])
+    where D: fmt::Display
+{
+    if found != expected {
+        // TODO: If the data appears to be actual binary, do a better job
+        // of printing it.
+        panic!("expected {} to equal {:?}, found {:?}",
+               source,
+               String::from_utf8_lossy(expected).as_ref(),
+               String::from_utf8_lossy(found).as_ref());
+    }
+}
+
+/// Extension methods for `std::process::Command`.
+pub trait CommandExt {
+    /// Spawn this command, passing it the specified data on standard
+    /// input.
+    fn output_with_stdin<S: AsRef<[u8]>>(&mut self, input: S)
+                                         -> io::Result<process::Output>;
+}
+
+impl CommandExt for process::Command {
+    fn output_with_stdin<S>(&mut self, input: S)
+                            -> io::Result<process::Output>
+        where S: AsRef<[u8]>
+    {
+        let input = input.as_ref().to_owned();
+        let mut child: process::Child = self.stdin(process::Stdio::piped())
+            .stdout(process::Stdio::piped())
+            .stderr(process::Stdio::piped())
+            .spawn()
+            .expect("error running command");
+        let mut stdin = child.stdin.take()
+            .expect("std in is unexpectedly missing");
+        let worker = thread::spawn(move || {
+            stdin.write_all(&input)
+                .expect("could not write to stdin");
+            stdin.flush()
+                .expect("could not flush data to child's stdin");
+        });
+        let result = child.wait_with_output();
+        worker.join().expect("stdin writer failed");
+        result
+    }
+}
+
+/// Extension methods for `std::process::Output`.
+pub trait OutputExt {
+    /// Get standard output as a `str`.
+    fn stdout_str(&self) -> &str;
+
+    /// Get standard error as a `str`.
+    fn stderr_str(&self) -> &str;
+}
+
+impl OutputExt for process::Output {
+    fn stdout_str(&self) -> &str {
+        str::from_utf8(&self.stdout)
+            .expect("stdout was not UTF-8 text")
+    }
+
+    fn stderr_str(&self) -> &str {
+        str::from_utf8(&self.stderr)
+            .expect("stderr was not UTF-8 text")
+    }
+}
+
+/// We define `expect_status` on quite a few related types to support
+/// different calling patterns.
+pub trait ExpectStatus {
+    /// Expect the child process to succeed, and return a
+    /// `std::process::Output` object with its output.
+    fn expect_success(self) -> process::Output;
+}
+
+impl ExpectStatus for process::Output {
+    fn expect_success(self) -> process::Output {
+        if !self.status.success() {
+            io::stdout().write_all(&self.stdout)
+                .expect("could not write to stdout");
+            io::stderr().write_all(&self.stderr)
+                .expect("could not write to stderr");
+            panic!("expected command to succeed, got {:?}", self.status)
+        }
+        self
+    }
+}
+
+impl<ES: ExpectStatus, E: fmt::Debug> ExpectStatus for Result<ES, E> {
+    fn expect_success(self) -> process::Output {
+        // Unwrap the result, fail on error, and pass `expect_success` to
+        // our wrapped type.
+        match self {
+            Ok(es) => es.expect_success(),
+            Err(err) => panic!("error running command: {:?}", err),
+        }
+    }
+}
+
+impl<'a> ExpectStatus for &'a mut process::Command {
+    fn expect_success(self) -> process::Output {
+        self.output().expect_success()
+    }
+}
+
+impl ExpectStatus for process::Child {
+    fn expect_success(self) -> process::Output {
+        self.wait_with_output().expect_success()
     }
 }

--- a/cli_test_dir/src/lib.rs
+++ b/cli_test_dir/src/lib.rs
@@ -61,7 +61,8 @@
 //! top-level of our crate, and `expect_path` can be used to make sure an
 //! output file exists:
 //!
-//! ```
+//! ```rust,no_run
+//! # // Don't run because `cp` will have path problems on Windows.
 //! # use cli_test_dir::*;
 //! let testdir = TestDir::new("cp", "cp_copies_files");
 //! testdir.cmd()

--- a/opus_tools/tests/opusraw2txt.rs
+++ b/opus_tools/tests/opusraw2txt.rs
@@ -1,6 +1,6 @@
 extern crate cli_test_dir;
 
-use cli_test_dir::TestDir;
+use cli_test_dir::*;
 use std::io;
 use std::io::prelude::*;
 use std::str::from_utf8;
@@ -10,26 +10,16 @@ fn parse_file() {
     let testdir = TestDir::new("opusraw2txt", "parse_file");
     let output = testdir.cmd()
         .arg(testdir.src_path("../fixtures/opus.raw.tar.gz"))
-        .output()
-        .expect("could not run opusraw2txt");
-    if !output.status.success() {
-        io::stderr().write(&output.stderr).expect("write stderr");
-    }
-    assert!(output.status.success());
-    assert!(from_utf8(&output.stdout).unwrap().find("Sentence 1").is_some());
-    assert!(from_utf8(&output.stderr).unwrap().find("4 sentences").is_some());
+        .expect_success();
+    assert!(output.stdout_str().contains("Sentence 1"));
+    assert!(output.stderr_str().contains("4 sentences"));
 }
 
 #[test]
 #[ignore]
 fn parse_large_file() {
     let testdir = TestDir::new("opusraw2txt", "parse_large_file");
-    let output = testdir.cmd()
+    testdir.cmd()
         .arg(testdir.src_path("../private/opus_open_subtitles/ca.raw.tar.gz"))
-        .output()
-        .expect("could not run opusraw2txt");
-    if !output.status.success() {
-        io::stderr().write(&output.stderr).expect("write stderr");
-    }
-    assert!(output.status.success());
+        .expect_success();
 }

--- a/subtitles2srt/tests/tests.rs
+++ b/subtitles2srt/tests/tests.rs
@@ -5,14 +5,12 @@
 
 extern crate cli_test_dir;
 
-use cli_test_dir::TestDir;
+use cli_test_dir::*;
 
 #[test]
 fn does_not_fail() {
     let workdir = TestDir::new("subtitles2srt", "does_not_fail");
-    let status = workdir.cmd()
+    workdir.cmd()
         .arg(workdir.src_path("../fixtures/example.idx"))
-        .status()
-        .expect("could not run command");
-    assert!(status.success());
+        .expect_success();
 }

--- a/vobsub/Cargo.toml
+++ b/vobsub/Cargo.toml
@@ -25,6 +25,6 @@ error-chain = "0.8.1"
 image = { version = "0.12.2", default-features = false }
 lazy_static = "0.2.2"
 log = "0.3.6"
-nom = "2.1.0"
+nom = "2.1.0, <2.2.0"
 regex = "0.2.1"
 safemem = "0.2.0"

--- a/vobsub2png/tests/tests.rs
+++ b/vobsub2png/tests/tests.rs
@@ -5,19 +5,17 @@
 
 extern crate cli_test_dir;
 
-use cli_test_dir::TestDir;
+use cli_test_dir::*;
 
 #[test]
 fn generates_png_and_json_files() {
     let workdir =
         TestDir::new("vobsub2png", "generates_png_and_json_files");
-    let status = workdir.cmd()
+    workdir.cmd()
         .arg("-o")
         .arg("out")
         .arg(workdir.src_path("../fixtures/example.idx"))
-        .status()
-        .expect("could not run command");
-    assert!(status.success());
+        .expect_success();
     workdir.expect_path("out/index.json");
     workdir.expect_path("out/0000.png");
     workdir.expect_path("out/0001.png");
@@ -27,11 +25,9 @@ fn generates_png_and_json_files() {
 fn defaults_out_dir_based_on_input_name() {
     let workdir =
         TestDir::new("vobsub2png", "defaults_out_dir_based_on_input_name");
-    let status = workdir.cmd()
+    workdir.cmd()
         .arg(workdir.src_path("../fixtures/example.idx"))
-        .status()
-        .expect("could not run command");
-    assert!(status.success());
+        .expect_success();
     workdir.expect_path("example_subtitles/index.json");
     workdir.expect_path("example_subtitles/0000.png");
     workdir.expect_path("example_subtitles/0001.png");


### PR DESCRIPTION
Ping @seamusabshere: I needed to upgrade my personal testing library to better test https://github.com/faradayio/scrubcsv . Can you please confirm that I'm authorized to release these changes under the same terms as the existing library? (It uses a [CC0 license / public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/), which places the code into the public domain in most jurisdictions and offers a very broad fallback license otherwise.)

We can now:

- Easily check status without lots of boilerplate.
- Easily check stderr and stdout without lots of boilerplate.
- Create input files.
- Pass data on stdin.
- Check the contents of output files.