### PR TITLE
Fix compilation error in all crates by updating `image`

### DIFF
--- a/subtitle_ocr/Cargo.toml
+++ b/subtitle_ocr/Cargo.toml
@@ -11,7 +11,7 @@ vobsub = { path = "../vobsub", version = "0.2" }
 
 [dependencies]
 cast = "0.2.0"
-error-chain = "0.8.1"
+error-chain = "0.10.0"
 image = { version = "0.13.0", default-features = false, features = ["png_codec"] }
 lazy_static = "0.2"
 log = "0.3.6"

--- a/subtitle_ocr/Cargo.toml
+++ b/subtitle_ocr/Cargo.toml
@@ -12,7 +12,7 @@ vobsub = { path = "../vobsub", version = "0.2" }
 [dependencies]
 cast = "0.2.0"
 error-chain = "0.8.1"
-image = { version = "0.12.2", default-features = false, features = ["png_codec"] }
+image = { version = "0.13.0", default-features = false, features = ["png_codec"] }
 lazy_static = "0.2"
 log = "0.3.6"
 palette = "0.2.1"

--- a/subtitles2srt/Cargo.toml
+++ b/subtitles2srt/Cargo.toml
@@ -13,7 +13,7 @@ cli_test_dir = { version = "0.1", path = "../cli_test_dir" }
 docopt = "0.7.0"
 env_logger = "0.4.0"
 error-chain = "0.8.1"
-image = { version = "0.12.2", default-features = false, features = ["png_codec"] }
+image = { version = "0.13.0", default-features = false, features = ["png_codec"] }
 log = "0.3.6"
 rustc-serialize = "0.3.22"
 subtitle_ocr = { version = "0.1", path = "../subtitle_ocr" }

--- a/subtitles2srt/Cargo.toml
+++ b/subtitles2srt/Cargo.toml
@@ -12,7 +12,7 @@ cli_test_dir = { version = "0.1", path = "../cli_test_dir" }
 [dependencies]
 docopt = "0.7.0"
 env_logger = "0.4.0"
-error-chain = "0.8.1"
+error-chain = "0.10.0"
 image = { version = "0.13.0", default-features = false, features = ["png_codec"] }
 log = "0.3.6"
 rustc-serialize = "0.3.22"

--- a/vobsub/Cargo.toml
+++ b/vobsub/Cargo.toml
@@ -21,7 +21,7 @@ glob = "0.2.11"
 
 [dependencies]
 cast = "0.2.0"
-error-chain = "0.8.1"
+error-chain = "0.10.0"
 image = { version = "0.13.0", default-features = false }
 lazy_static = "0.2.2"
 log = "0.3.6"

--- a/vobsub/Cargo.toml
+++ b/vobsub/Cargo.toml
@@ -22,7 +22,7 @@ glob = "0.2.11"
 [dependencies]
 cast = "0.2.0"
 error-chain = "0.8.1"
-image = { version = "0.12.2", default-features = false }
+image = { version = "0.13.0", default-features = false }
 lazy_static = "0.2.2"
 log = "0.3.6"
 nom = "2.1.0, <2.2.0"

--- a/vobsub2png/Cargo.toml
+++ b/vobsub2png/Cargo.toml
@@ -15,7 +15,7 @@ cli_test_dir = { version = "0.1.0", path = "../cli_test_dir" }
 [dependencies]
 docopt = "0.7.0"
 env_logger = "0.4.0"
-error-chain = "0.8.1"
+error-chain = "0.10.0"
 image = { version = "0.13.0", default-features = false, features = ["png_codec"] }
 log = "0.3.6"
 rustc-serialize = "0.3.22"

--- a/vobsub2png/Cargo.toml
+++ b/vobsub2png/Cargo.toml
@@ -16,7 +16,7 @@ cli_test_dir = { version = "0.1.0", path = "../cli_test_dir" }
 docopt = "0.7.0"
 env_logger = "0.4.0"
 error-chain = "0.8.1"
-image = { version = "0.12.2", default-features = false, features = ["png_codec"] }
+image = { version = "0.13.0", default-features = false, features = ["png_codec"] }
 log = "0.3.6"
 rustc-serialize = "0.3.22"
 serde = "0.9"


### PR DESCRIPTION
Version 0.12.4 of `image` produces compilation errors, while 0.13.0 does not. This commit updates `image` in all sub-projects. No other changes seem to be needed in any project. All tests work on my machine.